### PR TITLE
Fix missing rows from GeoNames cities1000.txt.

### DIFF
--- a/reverse_geocoder/__init__.py
+++ b/reverse_geocoder/__init__.py
@@ -124,7 +124,7 @@ class RGeocoder:
             print 'Creating formatted geocoded file...'
             writer = csv.DictWriter(open(local_filename,'wb'),fieldnames=RG_COLUMNS)
             rows = []
-            for row in csv.reader(open(cities1000_filename,'rb'),delimiter='\t'):
+            for row in csv.reader(open(cities1000_filename,'rb'),delimiter='\t',quoting=csv.QUOTE_NONE):
                 lat = row[GN_COLUMNS['latitude']]
                 lon = row[GN_COLUMNS['longitude']]
                 name = row[GN_COLUMNS['asciiName']]


### PR DESCRIPTION
This fixes the parsing of the geonames CSV, you can reproduce the problem like this

 ```
import csv
import sys
csv.field_size_limit(sys.maxsize)
count1 = 0
count2 = 0
count3 = 0
for row in open('cities1000.txt','rb'):
  count1 = count1 + 1
for row in csv.reader(open('cities1000.txt','rb'),delimiter='\t'):
  count2 = count2 + 1
for row in csv.reader(open('cities1000.txt','rb'),delimiter='\t',quoting=csv.QUOTE_NONE):
  count3 = count3 + 1
print count1, count2, count3
```

outputs
```
144348 138630 144348
```

adding the quoting option corrects the 6000+ missing rows in the final csv.