### PR TITLE
Support for custom CSV datasource

### DIFF
--- a/reverse_geocoder/__init__.py
+++ b/reverse_geocoder/__init__.py
@@ -63,7 +63,7 @@ def singleton(cls):
     instances = {}
     def getinstance(**kwargs):
         key = tuple([ cls ] + kwargs.values())
-        if cls not in instances:
+        if key not in instances:
             instances[key] = cls(**kwargs)
         return instances[key]
     return getinstance

--- a/reverse_geocoder/__init__.py
+++ b/reverse_geocoder/__init__.py
@@ -61,18 +61,21 @@ E2 = 0.00669437999014
 
 def singleton(cls):
     instances = {}
-    def getinstance(mode=2,verbose=True):
+    def getinstance(**kwargs):
+        key = tuple([ cls ] + kwargs.values())
         if cls not in instances:
-            instances[cls] = cls(mode=mode,verbose=verbose)
-        return instances[cls]
+            instances[key] = cls(**kwargs)
+        return instances[key]
     return getinstance
 
 @singleton
-class RGeocoder:
-    def __init__(self,mode=2,verbose=True):
+class RGeocoder (object):
+    def __init__(self,mode=2,path=RG_FILE,verbose=True):
         self.mode = mode
         self.verbose = verbose
-        coordinates, self.locations = self.extract(rel_path(RG_FILE))
+        if not os.path.exists(path):
+            path = rel_path(path)
+        coordinates, self.locations = self.extract(path)
         if mode == 1: # Single-process
             self.tree = KDTree(coordinates)
         else: # Multi-process

--- a/reverse_geocoder/__init__.py
+++ b/reverse_geocoder/__init__.py
@@ -98,7 +98,7 @@ class RGeocoder (object):
             if self.verbose:
                 print('Loading formatted geocoded file...')
             rows = csv.DictReader(open(local_filename,'rt'))
-        else:
+        elif local_filename.endswith(RG_FILE):
             gn_cities1000_url = GN_URL + GN_CITIES1000 + '.zip'
             gn_admin1_url = GN_URL + GN_ADMIN1
             gn_admin2_url = GN_URL + GN_ADMIN2
@@ -171,6 +171,8 @@ class RGeocoder (object):
             if self.verbose:
                 print('Removing extracted cities1000 to save space...')
             os.remove(cities1000_filename)
+        else:
+            raise Exception, "Geocoded file not found"
 
         # Load all the coordinates and locations
         geo_coords,locations = [],[]


### PR DESCRIPTION
I'm developing a project that requires me to be able to reverse geocode on different granularities (using the cities1000 dataset, plus a smaller dataset just of capital cities).

For this, I've extended `reverse_geocoder` to allow me to specify a custom CSV datasource when instantiating the `RGeocoder` object. 

This has also required an extended `@singleton` decorator, that instantiates a single object per unique argument set (in this case, one per CSV input).

It does not affect normal usage of the library.
