### PR TITLE
Update __init__.py

### DIFF
--- a/reverse_geocoder/__init__.py
+++ b/reverse_geocoder/__init__.py
@@ -288,7 +288,8 @@ def search(geo_coords, mode=2, verbose=True):
         raise TypeError('Expecting a tuple or a tuple/list of tuples')
     elif not isinstance(geo_coords[0], tuple):
         geo_coords = [geo_coords]
-
+    if len(geo_coords) == 1:
+        mode = 1
     _rg = RGeocoder(mode=mode, verbose=verbose)
     return _rg.query(geo_coords)
 


### PR DESCRIPTION
Some intuitive usage of reverse_geocoder might be to reverse one coordinates pair at a time. In this case mode 1 is more efficient I figured. HIH.