### PR TITLE
Use correct ECEF coordinates

### DIFF
--- a/reverse_geocoder/__init__.py
+++ b/reverse_geocoder/__init__.py
@@ -110,10 +110,11 @@ class RGeocoder(object):
         else:
             coordinates, self.locations = self.extract(rel_path(RG_FILE))
 
+        ecef_coordinates = geodetic_in_ecef(coordinates)
         if mode == 1: # Single-process
-            self.tree = KDTree(coordinates)
+            self.tree = KDTree(ecef_coordinates)
         else: # Multi-process
-            self.tree = KDTree_MP.cKDTree_MP(coordinates)
+            self.tree = KDTree_MP.cKDTree_MP(ecef_coordinates)
 
     def query(self, coordinates):
         """
@@ -121,10 +122,11 @@ class RGeocoder(object):
         Args:
         coordinates (list): List of tuple coordinates, i.e. [(latitude, longitude)]
         """
+        ecef_coordinates = geodetic_in_ecef(coordinates)
         if self.mode == 1:
-            _, indices = self.tree.query(coordinates, k=1)
+            _, indices = self.tree.query(ecef_coordinates, k=1)
         else:
-            _, indices = self.tree.pquery(coordinates, k=1)
+            _, indices = self.tree.pquery(ecef_coordinates, k=1)
         return [self.locations[index] for index in indices]
 
     def load(self, stream):
@@ -260,7 +262,7 @@ def geodetic_in_ecef(geo_coords):
 
     x = normal * np.cos(lat_r) * np.cos(lon_r)
     y = normal * np.cos(lat_r) * np.sin(lon_r)
-    z = normal * (1 - E2) * np.sin(lat)
+    z = normal * (1 - E2) * np.sin(lat_r)
 
     return np.column_stack([x, y, z])
 


### PR DESCRIPTION
- Fix bug in geodesic to ECEF coordinate conversion function
- Re-enable use of ECEF coordinates in KD-Tree

As pointed out in #10, when using ECEF coordinates without this fix for the latitude in the z-coordinate, some lookups result in wrong results:
```python
In [1]: import reverse_geocoder as rg
   ...: rg.search([(37.78674, -122.39222)])
Loading formatted geocoded file...
Out[1]:
[OrderedDict([('lat', '37.77993'),
              ('lon', '-121.97802'),
              ('name', 'San Ramon'),
              ('admin1', 'California'),
              ('admin2', 'Contra Costa County'),
              ('cc', 'US')])]
```

After the fix, this does not happen anymore:

```python
In [1]: import reverse_geocoder as rg
   ...: rg.search([(37.78674, -122.39222)])
Loading formatted geocoded file...
Out[1]:
[OrderedDict([('lat', '37.77493'),
              ('lon', '-122.41942'),
              ('name', 'San Francisco'),
              ('admin1', 'California'),
              ('admin2', 'San Francisco County'),
              ('cc', 'US')])]
```